### PR TITLE
feat: add recursive dynamic content replacement in buildResponse

### DIFF
--- a/src/utilities/build-response.ts
+++ b/src/utilities/build-response.ts
@@ -1,17 +1,32 @@
-export const buildResponse = async (content: string) => {
+export const buildResponse = async (content: any) => {
     const responseTemplate = (await import(
         `../response-templates/${process.env.LLM_NAME ?? 'chatgpt'}_res.json`,
-        {
-            assert: { type: 'json' },
+        { assert: { type: 'json' } }
+    )) as { default: any[] };
+
+    const newResponse = JSON.parse(JSON.stringify(responseTemplate.default[0]));
+
+// Recursive function to replace "DYNAMIC_CONTENT_HERE" with content
+    const replaceDynamicContent = (obj: any): any => {
+        if (typeof obj === 'string' && obj === 'DYNAMIC_CONTENT_HERE') {
+            return content;
         }
-    )) as { default: JSON[] };
 
-    const newResponse = JSON.parse(
-        JSON.stringify(responseTemplate.default[0]).replace(
-            /DYNAMIC_CONTENT_HERE/,
-            content,
-        ),
-    ) as JSON;
+        if (Array.isArray(obj)) {
+            return obj.map(replaceDynamicContent);
+        }
 
-    return newResponse;
+        if (typeof obj === 'object' && obj !== null) {
+            const newObj: any = {};
+            for (const key in obj) {
+                newObj[key] = replaceDynamicContent(obj[key]);
+            }
+
+            return newObj;
+        }
+
+        return obj;
+    };
+
+    return replaceDynamicContent(newResponse);
 };


### PR DESCRIPTION
Refactored buildResponse to use a recursive function that replaces all instances of "DYNAMIC_CONTENT_HERE" with the provided content.  Improves flexibility and ensures nested structures are properly updated.